### PR TITLE
Add .spec to AllCops/Exclude

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "config/puma.rb"
     - "config/unicorn.rb"
     - "Capfile"
+    - "**/*.spec"  # .spec file should be an RPM spec file not an RSpec file
   DisplayCopNames: true
 
 #################### Layout ################################


### PR DESCRIPTION
社内で、Rubyなファイルとして .spec 拡張子を使っているのは1件だけで、かつ広くRPMのspecファイルとして使われる拡張子なので対象から外したいです
