### PR TITLE
Fix for rubocop-rails

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 Rails:
   Enabled: true
 

--- a/retrieva-cop.gemspec
+++ b/retrieva-cop.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.50"
+  spec.add_dependency "rubocop", ">= 0.72"
+  spec.add_dependency "rubocop-rails", ">= 2.3.2"
   spec.add_dependency "rubocop-rspec", ">= 1.18.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
From rubocop 0.72, rubocop-rails is separated from rubocop.

See http://koic.hatenablog.com/entry/extract-rails-cops-from-rubocop-core